### PR TITLE
rename role

### DIFF
--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -12,4 +12,4 @@
         package: apache2-utils
   roles:
     - apache_httpd
-    - apache_exporter-role
+    - prometheus_apache_exporter-role


### PR DESCRIPTION
### Description of the Change

add prefix promethus to role name 


### Benefits

Identify exporter target and keep organization naming conventions


