### PR TITLE
support apache-exporter v0 8 0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,3 +28,9 @@ apache_exporter_option_log_level: info # [debug, info, warn, error, fatal, panic
 apache_exporter_option_scrape_uri: http://localhost/server-status?auto
 apache_exporter_option_telemetry_address: ":9117"
 apache_exporter_option_telemetry_endpoint: /metrics
+
+apache_exporter_command_args:
+  - -scrape_uri="{{ apache_exporter_option_scrape_uri }}"
+  - -insecure={{ apache_exporter_option_insecure }}
+  - -telemetry.address="{{ apache_exporter_option_telemetry_address }}"
+  - -telemetry.endpoint="{{ apache_exporter_option_telemetry_endpoint }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,8 +29,16 @@ apache_exporter_option_scrape_uri: http://localhost/server-status?auto
 apache_exporter_option_telemetry_address: ":9117"
 apache_exporter_option_telemetry_endpoint: /metrics
 
-apache_exporter_command_args:
-  - -scrape_uri="{{ apache_exporter_option_scrape_uri }}"
+apache_exporter_command_args_stdlib:
+  - -scrape_uri={{ apache_exporter_option_scrape_uri }}
   - -insecure={{ apache_exporter_option_insecure }}
-  - -telemetry.address="{{ apache_exporter_option_telemetry_address }}"
-  - -telemetry.endpoint="{{ apache_exporter_option_telemetry_endpoint }}"
+  - -telemetry.address={{ apache_exporter_option_telemetry_address }}
+  - -telemetry.endpoint={{ apache_exporter_option_telemetry_endpoint }}
+
+apache_exporter_command_args_kingpin:
+  - --scrape_uri={{ apache_exporter_option_scrape_uri }}
+  - "{{ apache_exporter_option_insecure | bool | ternary('--insecure', '') }}"
+  - --telemetry.address={{ apache_exporter_option_telemetry_address }}
+  - --telemetry.endpoint={{ apache_exporter_option_telemetry_endpoint }}
+
+apache_exporter_command_args: "{{ apache_exporter_version is version('0.8.0', '>=') | ternary(apache_exporter_command_args_kingpin, apache_exporter_command_args_stdlib) }}"

--- a/templates/apache_exporter.service.j2
+++ b/templates/apache_exporter.service.j2
@@ -8,7 +8,7 @@ User={{ apache_exporter_user }}
 Group={{ apache_exporter_group }}
 RuntimeDirectory=apache_exporter
 
-ExecStart=/bin/sh -c '{{ apache_exporter_install_path }}/apache_exporter -scrape_uri="{{ apache_exporter_option_scrape_uri }}" -insecure={{ apache_exporter_option_insecure }} -telemetry.address="{{ apache_exporter_option_telemetry_address }}" -telemetry.endpoint="{{ apache_exporter_option_telemetry_endpoint }}" >> {{ apache_exporter_log_file }} 2>> {{ apache_exporter_error_log_file }}'
+ExecStart=/bin/sh -c '{{ apache_exporter_install_path }}/apache_exporter {{ apache_exporter_command_args | join(" ") }} >> {{ apache_exporter_log_file }} 2>> {{ apache_exporter_error_log_file }}'
 
 ExecStartPost=/bin/sh -c "echo $MAINPID > /run/apache_exporter/apache_exporter.pid"
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
### Description of the Change
upstream project has migrated its flag parsing library to Kingpin in [v0.8.0](https://github.com/Lusitaniae/apache_exporter/releases/tag/v0.8.0)
As a consequence, it now requires flags to be preceded by 2 dashes rather than a single one, and the `--insecure` flag's boolean value is now derived from the presence of the flag rather than by setting it explicitely.

This PR provides support to the role for this new way of handling flags on the apache exporter side, without breaking backward compatibility
