### PR TITLE
fix condition. fixes issue #11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 
 ## [Unreleased](https://github.com/idealista/prometheus_apache_exporter_role/tree/develop)
+- *[#11](https://github.com/idealista/prometheus_apache_exporter_role/issues/11) Fixed syntax error* @mbenabda
 
 ## [2.0.0](https://github.com/idealista/prometheus_haproxy_exporter_role/tree/2.0.0)
 ### [Full Changelog](https://github.com/idealista/prometheus_haproxy_exporter_role/compare/1.0.0...2.0.0)

--- a/tasks/check.yml
+++ b/tasks/check.yml
@@ -15,7 +15,7 @@
 
 - name: APACHE_EXPORTER | Set installed fact
   set_fact:
-    apache_exporter_is_installed: "{{ apache_exporter_is_installed_command.stdout }}"
+    apache_exporter_is_installed: "{{ apache_exporter_is_installed_command.stdout | bool }}"
 
 - name: APACHE_EXPORTER | Set same version fact
   set_fact:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -43,11 +43,11 @@
     mode: 0755
     owner: "{{ apache_exporter_user }}"
     group: "{{ apache_exporter_group }}"
-  when: apache_exporter_is_installed is false or apache_exporter_is_different_version is true
+  when: not apache_exporter_is_installed or apache_exporter_is_different_version
 
 - name: APACHE_EXPORTER | Link binary
   file:
     src: "{{ apache_exporter_install_path }}/{{ apache_exporter_exec_name }}"
     dest: "/usr/bin/{{ apache_exporter_exec_name }}"
     state: link
-  when: apache_exporter_is_installed is false or apache_exporter_is_different_version is true
+  when: not apache_exporter_is_installed or apache_exporter_is_different_version


### PR DESCRIPTION
### Description of the Change

there were syntatic errors in `when` conditions in the `install` task, leading to the following error, making it impossible to either run or upgrade the role to v2.0.0:
```
TASK [apache-exporter : APACHE_EXPORTER | Download and extract package] ************************************************************************************************************************************
task path: /.../.ansible/roles/apache-exporter/tasks/install.yml:37
fatal: [xxx.xxx.xxx.xxx]: FAILED! => {"msg": "The conditional check 'apache_exporter_is_installed is false or apache_exporter_is_different_version is true' failed. The error was: template error while templating string: no test named 'false'. String: {% if apache_exporter_is_installed is false or apache_exporter_is_different_version is true %} True {% else %} False {% endif %}\n\nThe error appears to be in '/.../.ansible/roles/apache-exporter/tasks/install.yml': line 37, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: APACHE_EXPORTER | Download and extract package\n  ^ here\n"}
```
 
### Benefits

role can be run.

### Applicable Issues
issue #11 