### PR TITLE
fix(tasks): update deprecated 'include' to 'include_tasks'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,21 +1,20 @@
 ---
-
 - name: APACHE_EXPORTER | Check
-  include: check.yml
+  include_tasks: check.yml
   tags:
     - apache_exporter_check
 
 - name: APACHE_EXPORTER | Install
-  include: install.yml
+  include_tasks: install.yml
   tags:
     - apache_exporter_install
 
 - name: APACHE_EXPORTER | Configure
-  include: config.yml
+  include_tasks: config.yml
   tags:
     - apache_exporter_configure
 
 - name: APACHE_EXPORTER | Service
-  include: service.yml
+  include_tasks: service.yml
   tags:
     - apache_exporter_service


### PR DESCRIPTION
### Description of the Change

Update the deprecated/removed task `include` to include_tasks

```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```
